### PR TITLE
feat: make RadGUI constructor options optional

### DIFF
--- a/docs/rad-gui-class.md
+++ b/docs/rad-gui-class.md
@@ -17,8 +17,19 @@
 
 ### Constructor
 ```typescript
-const radGui = new RadGUI(options?: GuiOptions)
+const radGui = new RadGUI();           // With default options
+const radGui = new RadGUI(options);    // With custom options
 ```
+
+**Parameters:**
+- `options` (object, optional): Configuration options - same as GUI class
+  - `title` (string): Title of the GUI (default: 'Controls')
+  - `width` (number): Width in pixels
+  - `autoPlace` (boolean): Whether to automatically append to document.body (default: true)
+  - `container` (HTMLElement): Custom container element
+  - `closeFolders` (boolean): Whether folders should be closed by default
+  - `injectStyles` (boolean): Whether to inject CSS styles (default: true)
+  - `touchStyles` (boolean): Whether to include touch-friendly styles (default: true)
 
 ### Control Methods
 

--- a/examples/ts-sample/readme.md
+++ b/examples/ts-sample/readme.md
@@ -108,9 +108,13 @@ gui.add(object, 'action');               // Button (function property)
 
 ### RadGUI Explicit Control Creation
 ```typescript
+// Create RadGUI with or without options
+const radGui = new RadGUI();                    // Default options
+const radGui = new RadGUI({ title: 'My GUI' }); // Custom options
+
 // Explicit method calls
 radGui.addNumber(object, 'property', 0, 100, 1);
-radGui.addText(object, 'enabled');       // Note: text representation
+radGui.addToggle(object, 'enabled');      // Proper boolean control
 radGui.addText(object, 'text');
 radGui.addColor(object, 'color');
 radGui.addOption(object, 'mode', ['opt1', 'opt2']);

--- a/lib/gui.d.ts
+++ b/lib/gui.d.ts
@@ -63,7 +63,7 @@ export declare class GUI {
     foldersRecursive(): unknown[];
 }
 export declare class RadGUI extends GUI {
-    constructor(options: any);
+    constructor(options?: any);
     addFolder(title: string): RadGUI;
     addButton(title: string, callback: () => void): FunctionControl;
     addColor<T, K extends keyof T>(object: T, property: K, rgbScale?: number): ColorControl;

--- a/src/gui.ts
+++ b/src/gui.ts
@@ -568,7 +568,7 @@ export class GUI {
 }
 
 export class RadGUI extends GUI {
-  constructor(options: any) {
+  constructor(options?: any) {
     super(options);
   }
 

--- a/test/rad-gui.test.ts
+++ b/test/rad-gui.test.ts
@@ -1,4 +1,4 @@
-import { RadGUI } from '../src/gui';
+import { RadGUI, GUI } from '../src/gui';
 
 describe('RadGUI', () => {
   let gui: RadGUI;
@@ -29,6 +29,17 @@ describe('RadGUI', () => {
       expect(gui.children).toEqual([]);
       expect(gui.controllers).toEqual([]);
       expect(gui.folders).toEqual([]);
+    });
+
+    test('should create RadGUI with no options', () => {
+      const noOptionsGui = new RadGUI();
+      
+      expect(noOptionsGui).toBeInstanceOf(RadGUI);
+      expect(noOptionsGui).toBeInstanceOf(GUI);
+      expect(noOptionsGui.domElement).toBeDefined();
+      expect(noOptionsGui._title).toBe('Controls'); // Default title
+      
+      noOptionsGui.destroy();
     });
 
     test('should accept constructor options', () => {


### PR DESCRIPTION
- Make RadGUI constructor parameter optional (options?: any)
- Add comprehensive test for RadGUI with no options
- Update type definitions to reflect optional constructor
- Update documentation with usage examples for both patterns
- Ensure consistency with base GUI class constructor pattern

BREAKING CHANGE: RadGUI constructor now accepts optional parameters, improving developer experience and TypeScript compatibility.

Closes: Constructor parameter consistency